### PR TITLE
Rework

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -112,11 +112,6 @@ module.exports = NodeHelper.create({
 	},
 
 	parseInlineJson (str) {
-		try {
-			const object = eval?.(`"use strict";(${str})`);
-			return object;
-		} catch (error) {
-			Log.error(`MMM-WetterOnline: Error parsing inline JSON: ${error}`);
-		}
+		return eval?.(`"use strict";(${str})`);
 	}
 });

--- a/node_helper.js
+++ b/node_helper.js
@@ -30,11 +30,12 @@ module.exports = NodeHelper.create({
 
 	findGid (city, body) {
 		const exp = /gid : "([^"]+)"/s;
-		const gid = body.match(exp);
+		const match = body.match(exp);
 	
-		if(gid) {
-			Log.info(`MMM-WetterOnline: The gid of city "${city}" is ${gid[1]}.`)
-			return gid[1];
+		if(match) {
+			const gid = match[1];
+			Log.info(`MMM-WetterOnline: The gid of city "${city}" is ${gid}.`)
+			return gid;
 		} else {
 			Log.error(`MMM-WetterOnline: The gid of city "${city}" could not be extracted.`);
 		}


### PR DESCRIPTION
1. simplify regexp in `findGid`
1. add some console outputs
1. handle wrong city names by checking if there is a gid
1. set texts for currConditions to `""` instead of `null` (till now `null` was displayed for some cities (like new-york))

This seems also fix #8. Because I also couldn't run the module with the city "heddert" before.